### PR TITLE
Adjust the donut legend regex and xpath

### DIFF
--- a/src/widgetastic_patternfly4/donutchart.py
+++ b/src/widgetastic_patternfly4/donutchart.py
@@ -9,7 +9,7 @@ from widgetastic.widget import (
 )
 from widgetastic.xpath import quote
 
-LEGEND_DETAIL = re.compile(r"(.*?): ([\d]+)")
+LEGEND_DETAIL = re.compile(r"(.*?)[:]? \(?([\d]+)\)?")
 
 
 def _get_legend_item(text):
@@ -51,13 +51,13 @@ class DonutChart(View):
     @View.nested
     class legend(View):  # noqa
         ROOT = "./div[contains(@class, 'VictoryContainer')]"
-        ALL_ITEMS = "./*[name()='svg']/*[name()='g']/*[name()='text']/*[name()='tspan']"
+        ALL_ITEMS = "./*[name()='svg']//*[name()='text']/*[name()='tspan']"
 
         @ParametrizedView.nested
         class item(ParametrizedView, ClickableMixin):  # noqa
             PARAMETERS = ("label_text",)
             ROOT = ParametrizedLocator(
-                ".//*[name()='svg']/*[name()='g']/*[name()='text']"
+                ".//*[name()='svg']//*[name()='text']"
                 "/*[name()='tspan' and contains(., '{label_text}')]"
             )
 


### PR DESCRIPTION
Advisor had to custom build their own donut chart legend. These small changes should allow the DonutChart to work with both the custom legend and the standard pf4 legend. It's very similar to the legend we have here, just missing the intermediate `g` tag in the legend xpath, and the legend text is slightly different. 