### PR TITLE
fix ITEMS_LOCATOR for Dropdown widget

### DIFF
--- a/src/widgetastic_patternfly4/dropdown.py
+++ b/src/widgetastic_patternfly4/dropdown.py
@@ -32,7 +32,7 @@ class Dropdown(Widget):
         ".//button[contains(@class, 'pf-c-options-menu__toggle-button') or "
         "contains(@class, 'pf-c-dropdown__toggle')]"
     )
-    ITEMS_LOCATOR = ".//ul[@class='pf-c-dropdown__menu']/li"
+    ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-c-dropdown__menu')]/li"
     ITEM_LOCATOR = (
         ".//*[self::a or self::button][contains(@class, 'pf-c-dropdown__menu-item')"
         " and normalize-space(.)={}]"


### PR DESCRIPTION
Fixed ITEM_LOCATOR for dropdown widget - class needs to contain pf-c-dropdown__menu but not to be equal to  pf-c-dropdown__menu.

