### PR TITLE
Refactor Donut Chart into separate classes

### DIFF
--- a/src/widgetastic_patternfly4/donutchart.py
+++ b/src/widgetastic_patternfly4/donutchart.py
@@ -9,25 +9,70 @@ from widgetastic.widget import (
 )
 from widgetastic.xpath import quote
 
-LEGEND_DETAIL = re.compile(r"(.*?): ([\d]+)")
+
+class DonutLegendItem(ParametrizedView, ClickableMixin):
+    PARAMETERS = ("label_text",)
+    ROOT = ParametrizedLocator(
+        ".//*[name()='svg']/*[name()='g']/*[name()='text']"
+        "/*[name()='tspan' and contains(., '{label_text}')]"
+    )
+    ALL_ITEMS = "./*[name()='svg']/*[name()='g']/*[name()='text']/*[name()='tspan']"
+    LEGEND_ITEM_REGEX = re.compile(r"(.*?): ([\d]+)")
+
+    @classmethod
+    def _get_legend_item(cls, text):
+        match = cls.LEGEND_ITEM_REGEX.match(text)
+        if match:
+            return match.group(1), match.group(2)
+        else:
+            return text, None
+
+    @property
+    def label(self):
+        return self._get_legend_item(self.browser.text(self))[0]
+
+    @property
+    def value(self):
+        return self._get_legend_item(self.browser.text(self))[1]
+
+    @classmethod
+    def all(cls, browser):
+        return [(browser.text(el),) for el in browser.elements(cls.ALL_ITEMS)]
 
 
-def _get_legend_item(text):
-    match = LEGEND_DETAIL.match(text)
-    if match:
-        return match.group(1), match.group(2)
-    else:
-        return text, None
+class DonutLegend(View):
+    ROOT = "./div[contains(@class, 'VictoryContainer')]"
+
+    item = ParametrizedView.nested(DonutLegendItem)
+
+    @property
+    def all_items(self):
+        result = []
+        for i in self.item:
+            result.append({"label": i.label, "value": i.value})
+        return result
+
+
+class DonutCircle(View):
+    ROOT = ".//div[*[name()='svg'][*[name()='text'] and not(*[name()='rect'])]]"
+    LABELS_LOCATOR = "./*[name()='svg']/*[name()='text']/*[name()='tspan']"
+
+    @property
+    def labels(self):
+        return [self.browser.text(elem) for elem in self.browser.elements(self.LABELS_LOCATOR)]
 
 
 class DonutChart(View):
     """
-        Represents the Donut Chart
-        from Patternfly 4 (https://www.patternfly.org/v4/documentation/react/charts/chartdonut)
+    Represents the Donut Chart
+    from Patternfly 4 (https://www.patternfly.org/v4/documentation/react/charts/chartdonut)
     """
 
     ROOT = ParametrizedLocator("{@locator}")
     BASE_LOCATOR = ".//div[@id={}]"
+
+    donut = View.nested(DonutCircle)
+    legend = View.nested(DonutLegend)
 
     def __init__(self, parent, id=None, locator=None, logger=None):
         """Create the widget"""
@@ -38,42 +83,3 @@ class DonutChart(View):
             self.locator = locator
         else:
             raise TypeError("You need to specify either id or locator")
-
-    @View.nested
-    class donut(View):  # noqa
-        ROOT = ".//div[*[name()='svg'][*[name()='text'] and not(*[name()='rect'])]]"
-        LABELS_LOCATOR = "./*[name()='svg']/*[name()='text']/*[name()='tspan']"
-
-        @property
-        def labels(self):
-            return [self.browser.text(elem) for elem in self.browser.elements(self.LABELS_LOCATOR)]
-
-    @View.nested
-    class legend(View):  # noqa
-        ROOT = "./div[contains(@class, 'VictoryContainer')]"
-        ALL_ITEMS = "./*[name()='svg']/*[name()='g']/*[name()='text']/*[name()='tspan']"
-
-        @ParametrizedView.nested
-        class item(ParametrizedView, ClickableMixin):  # noqa
-            PARAMETERS = ("label_text",)
-            ROOT = ParametrizedLocator(
-                ".//*[name()='svg']/*[name()='g']/*[name()='text']"
-                "/*[name()='tspan' and contains(., '{label_text}')]"
-            )
-
-            @property
-            def label(self):
-                return _get_legend_item(self.browser.text(self))[0]
-
-            @property
-            def value(self):
-                return _get_legend_item(self.browser.text(self))[1]
-
-        @property
-        def all_items(self):
-            els = self.browser.elements(self.ALL_ITEMS)
-            result = []
-            for el in els:
-                label, value = _get_legend_item(self.browser.text(el))
-                result.append({"label": label, "value": value})
-            return result


### PR DESCRIPTION
This allows for easier customization of the donut chart. For example, the advisor team uses the pf4 donut "circle" but they wrote a custom legend, which has slightly different locators for finding legend items. See the donut at https://cloud.redhat.com/insights/overview

I also went ahead and changed the parametrized "legend item" nested view to use an `all` classmethod, which I think is more in-line with how widgetastic was written to approach parametrized views. Instead of finding the item elements inside the `DonutLegend` view, we now let the `all` method on `DonutLegendItem` take care of doing that.

The end result is that no functionality/attributes/properties of the existing Views have changed ... just the class organization.

To override the standard donut chart to work with the Overview page, this is the code I can now use:
```python
class CustomLegendItem(DonutLegendItem):
    ROOT = ParametrizedLocator(
        ".//*[name()='svg']//*[name()='text']" "/*[name()='tspan' and contains(., '{label_text}')]"
    )
    ALL_ITEMS = "./*[name()='svg']/*[name()='text']/*[name()='tspan']"
    LEGEND_ITEM_REGEX = re.compile(r"(.*?)[:]? \(?([\d]+)\)?")


class CustomLegend(DonutLegend):
    ROOT = "./div[contains(@class, 'VictoryContainer')]"
    item = ParametrizedView.nested(CustomLegendItem)


class CustomCircle(DonutCircle):
    ROOT = (
        "./div[contains(@class, 'donut-chart-container')]/div[contains(@class, 'VictoryContainer')]"
    )


class CustomDonutChart(DonutChart):
    """
    Advisor UI uses the pf4 donut chart for the "circle", but they use a custom legend.
    """
    donut = View.nested(CustomCircle)
    legend = View.nested(CustomLegend)
```