### PR TITLE
Removed 'skip' mark for test_first_page

### DIFF
--- a/testing/test_pagination.py
+++ b/testing/test_pagination.py
@@ -10,7 +10,6 @@ def paginator(browser):
     paginator.set_per_page(20)
 
 
-@pytest.mark.skip
 def test_first_page(paginator):
     paginator.last_page()
     assert paginator.current_page == 27


### PR DESCRIPTION
Either it was a change in FF or in patternfly page, test is passing again in FF (and was working in Chrome all the time), so removing 'skip' mark.