### PR TITLE
Fixed switch label locator

### DIFF
--- a/src/widgetastic_patternfly4/switch.py
+++ b/src/widgetastic_patternfly4/switch.py
@@ -13,7 +13,10 @@ class Switch(GenericLocatorWidget):
     """
 
     CHECKBOX_LOCATOR = "./input"
-    LABEL = './span[contains(@class, "pf-c-switch__label")]'
+    LABEL = (
+        "./span[contains(@class, 'pf-m-on') and preceding-sibling::input[@checked] or "
+        "contains(@class, 'pf-m-off') and preceding-sibling::input[not(@checked)]]"
+    )
 
     @property
     def selected(self):


### PR DESCRIPTION
Both labels (for `on` and `off` states) are present in DOM at the same time, so we should pick the label according to switch state.

This fix works perfectly fine with "static" switch state (when it's just loaded), however, since currently nothing changes in DOM when switch is clicked, there's no way to determine correct label after state change. For more details, see patternfly/patternfly-react#2669