### PR TITLE
Change alert to use f-strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
       after_success:
       install: pip install -U pre-commit
       script: pre-commit run --all
+      after_failure:
+        - git diff
     - &test
       stage: test
       services:

--- a/src/widgetastic_patternfly4/alert.py
+++ b/src/widgetastic_patternfly4/alert.py
@@ -65,15 +65,14 @@ class Alert(Widget):
         else:
             raise ValueError(
                 "Could not find a proper alert type."
-                " Available classes: {!r} Alert has: {!r}".format(
-                    self.TYPE_MAPPING, self.browser.classes(self)
-                )
+                f"\nAvailable classes: {self.TYPE_MAPPING!r} "
+                f"\nAlert has: {self.browser.classes(self)!r}"
             )
 
     def assert_no_error(self):
         """Asserts that the warning is not of the error type."""
         if self.type == "error":
-            raise AssertionError("assert_no_error: {}".format(self.body))
+            raise AssertionError(f"assert_no_error: {self.body}")
 
     def __repr__(self):
-        return "{}({!r})".format(type(self).__name__, self.locator)
+        return f"{type(self).__name__}({self.locator!r})"


### PR DESCRIPTION
"enhancement"

Including a git-diff in travis Lint phase, to show changes from pre-commit failures.

Failing on unrelated test, `testing/test_chipgroup.py::test_chipgroup_toolbar FAILED                 [ 16%]`