### PR TITLE
Breadcrumb remove locator

### DIFF
--- a/src/widgetastic_patternfly4/breadcrumb.py
+++ b/src/widgetastic_patternfly4/breadcrumb.py
@@ -10,13 +10,6 @@ class BreadCrumb(Widget):
     ROOT = './/nav[contains(@class, "pf-c-breadcrumb")]/ol'
     ELEMENTS = ".//li"
 
-    def __init__(self, parent, locator=None, logger=None):
-        Widget.__init__(self, parent=parent, logger=logger)
-        self._locator = locator or self.ROOT
-
-    def __locator__(self):
-        return self._locator
-
     @property
     def _path_elements(self):
         return self.browser.elements(self.ELEMENTS)


### PR DESCRIPTION
I can wrap some deprecation warnings into the BreadCrumb constructor, if desired.

I searched, at least in InsightsQE, for uses of this component but didn't find any.

Design wise, I think classes which use ROOT should not be taking locator kwargs.

Failing on unrelated test, `testing/test_chipgroup.py::test_chipgroup_toolbar FAILED                 [ 16%]`