### PR TITLE
Add partial match support to breadcrumb click_location

### DIFF
--- a/src/widgetastic_patternfly4/breadcrumb.py
+++ b/src/widgetastic_patternfly4/breadcrumb.py
@@ -1,3 +1,4 @@
+from widgetastic.exceptions import WidgetOperationFailed
 from widgetastic.widget import Widget
 
 
@@ -32,10 +33,27 @@ class BreadCrumb(Widget):
         """
         return self.locations[-1] if self.locations else None
 
-    def click_location(self, name, handle_alert=False):
+    def click_location(self, name, partial=False, handle_alert=False):
         """Clicks a location present in the breadcrumbs by string name.
+
+        Args:
+            name: location name
+            partial(bool): Whether to use partial match
+            handle_alert: handle the browser alert and ensure page safe
         """
-        location = next(loc for loc in self._path_elements if self.browser.text(loc) == name)
+        try:
+            location = next(
+                loc
+                for loc in self._path_elements
+                if (not partial and (self.browser.text(loc) == name))
+                or (partial and (name in self.browser.text(loc)))
+            )
+        except StopIteration:
+            partial_msg = " with partial match" if partial else ""
+            locs = f" within locations: {self.locations}"
+            raise WidgetOperationFailed(
+                f'Breadcrumb location "{name}" not found{partial_msg}{locs}'
+            )
         self.browser.click(location, ignore_ajax=handle_alert)
         if handle_alert:
             self.browser.handle_alert(wait=2.0)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -27,7 +27,7 @@ def selenium(browser_name):
 def browser(selenium, request):
     name = request.module.__name__.split("_")[1]
     category = getattr(request.module, "CATEGORY", "components")
-    url = "https://patternfly-react.surge.sh/patternfly-4/documentation/react/{}/{}"
+    url = f"https://patternfly-react.surge.sh/patternfly-4/documentation/react/{category}/{name}"
     selenium.maximize_window()
-    selenium.get(url.format(category, name))
+    selenium.get(url)
     return Browser(selenium)

--- a/testing/test_breadcrumb.py
+++ b/testing/test_breadcrumb.py
@@ -1,3 +1,7 @@
+import re
+
+import pytest
+from widgetastic.exceptions import WidgetOperationFailed
 from widgetastic.widget import View
 
 from widgetastic_patternfly4 import BreadCrumb
@@ -14,3 +18,23 @@ def test_breadcrumb(browser):
     assert view.breadcrumb.locations[0].lower() == "section home"
     assert view.breadcrumb.read().lower() == "section landing"
     view.breadcrumb.click_location(view.breadcrumb.locations[0])
+    view.breadcrumb.click_location("title", partial=True)
+
+    failing_location = "definitely not in the example page"
+
+    # exception + message on full match
+    exception_match = re.escape(
+        f'Breadcrumb location "{failing_location}" '
+        f"not found within locations: {view.breadcrumb.locations}"
+    )
+    with pytest.raises(WidgetOperationFailed, match=exception_match):
+        view.breadcrumb.click_location(failing_location)
+
+    # exception + message on partial match
+    exception_match = re.escape(
+        f'Breadcrumb location "{failing_location}" '
+        "not found with partial match "
+        f"within locations: {view.breadcrumb.locations}"
+    )
+    with pytest.raises(WidgetOperationFailed, match=exception_match):
+        view.breadcrumb.click_location(failing_location, partial=True)


### PR DESCRIPTION
Add `partial` kwarg to `BreadCrumb.click_location`, update unit tests to cover the exception+message.

Failing on unrelated test, `testing/test_chipgroup.py::test_chipgroup_toolbar FAILED                 [ 16%]`