### PR TITLE
[WIP] Handle notifications when closing a modal

### DIFF
--- a/src/widgetastic_patternfly4/modal.py
+++ b/src/widgetastic_patternfly4/modal.py
@@ -22,6 +22,8 @@ class Modal(Widget):
     )
     TITLE = ".//h1[contains(@class, 'pf-c-title')]"
     CLOSE = ".//button[@aria-label='Close']"
+    NOTIFICATIONS = ".//div[contains(@class, 'pf-c-alert') and contains(@class, 'notification')]"
+    NOTIFICATION_ACTION = ".//div[contains(@class, 'pf-c-alert__action')]"
 
     def __init__(self, parent, locator=None, logger=None):
         super().__init__(parent, logger=logger)
@@ -37,8 +39,19 @@ class Modal(Widget):
         """Get WebElement of modal body."""
         return self.browser.element(self.BODY)
 
-    def close(self):
+    def close(self, close_notifications=True):
         """Close modal window."""
+        if close_notifications:
+            # close any alerts present
+            try:
+                notifications = self.root_browser.elements(self.NOTIFICATIONS)
+                for notification in notifications:
+                    action = self.root_browser.element(
+                        self.NOTIFICATION_ACTION, parent=notification
+                    )
+                    action.click()
+            except NoSuchElementException:
+                pass
         self.browser.click(self.browser.element(self.CLOSE))
 
     @property


### PR DESCRIPTION
Sometimes notifications can get in the way of the close button on a modal. As a temporary workaround, we can close the notifications before closing the modal. 