### PR TITLE
Fix to close an open drop down

### DIFF
--- a/src/widgetastic_patternfly4/dropdown.py
+++ b/src/widgetastic_patternfly4/dropdown.py
@@ -89,7 +89,7 @@ class Dropdown(Widget):
         try:
             self._verify_enabled()
             if self.is_open:
-                self.browser.click(self)
+                self.browser.click(self.BUTTON_LOCATOR)
         except (NoSuchElementException, DropdownDisabled):
             if ignore_nonpresent:
                 self.logger.info("%r hid so it was not possible to close it. But ignoring.", self)


### PR DESCRIPTION
This PR address the fix for the issue with unable to close the compact pagination dropdown after is open. 