### PR TITLE
Fix is_displayed bug from ChipGroup

### DIFF
--- a/src/widgetastic_patternfly4/chipgroup.py
+++ b/src/widgetastic_patternfly4/chipgroup.py
@@ -292,4 +292,4 @@ class ChipGroupToolbar(View):
     def is_displayed(self):
         # If we delete all chips the ROOT is still shown thus we need to check if there are
         # any chips.
-        return self.read() != {}
+        return super().is_displayed and self.read() != {}

--- a/src/widgetastic_patternfly4/chipgroup.py
+++ b/src/widgetastic_patternfly4/chipgroup.py
@@ -292,4 +292,4 @@ class ChipGroupToolbar(View):
     def is_displayed(self):
         # If we delete all chips the ROOT is still shown thus we need to check if there are
         # any chips.
-        return super().is_displayed and self.read() != {}
+        return self.browser.is_displayed(self) and self.read() != {}

--- a/src/widgetastic_patternfly4/chipgroup.py
+++ b/src/widgetastic_patternfly4/chipgroup.py
@@ -289,7 +289,7 @@ class ChipGroupToolbar(View):
         self.overflow.show_less()
 
     @property
-    def is_displayed(self):
+    def has_chips(self):
         # If we delete all chips the ROOT is still shown thus we need to check if there are
         # any chips.
-        return self.browser.is_displayed(self) and self.read() != {}
+        return self.read() != {}

--- a/testing/test_chipgroup.py
+++ b/testing/test_chipgroup.py
@@ -185,4 +185,4 @@ def test_chipgroup_toolbar(root_view):
 
     for group in view.chip_group_toolbar:
         group.remove_all_chips()
-    assert not view.chip_group_toolbar.is_displayed
+    assert not view.chip_group_toolbar.has_chips

--- a/testing/test_chipgroup.py
+++ b/testing/test_chipgroup.py
@@ -21,7 +21,9 @@ def chips_view(browser):
 @pytest.fixture(scope="module")
 def root_view(browser):
     class TestView(View):
-        ROOT = ".//main[@role='main']"
+        ROOT = ".//main"
+        non_existent_chip_group_toolbar = ChipGroupToolbar(locator="foobar-locator")
+        non_existent_chip_group = StandAloneChipGroup(locator="foobar-locator")
 
         chip_group_toolbar = ChipGroupToolbar(locator=".//div[@id='ws-react-c-chipgroup-toolbar']")
         chip_group_multiselect = StandAloneChipGroup(
@@ -47,6 +49,14 @@ def root_view(browser):
     )
 
     return view
+
+
+def test_non_existent_chips(root_view):
+
+    view = root_view
+
+    assert not view.non_existent_chip_group_toolbar.is_displayed
+    assert not view.non_existent_chip_group.is_displayed
 
 
 def test_chipgroup_chips(chips_view):
@@ -144,13 +154,13 @@ def test_chipgroup_toolbar(root_view):
     assert view.chip_group_toolbar.is_displayed
 
     groups = [group.label for group in view.chip_group_toolbar.get_groups()]
-    assert groups == ["Category 1", "Category 2", "Category 3"]
+    assert groups == ["Category 1 has a very long name", "Category 2", "Category 3"]
 
     groups = [group.label for group in view.chip_group_toolbar]
-    assert groups == ["Category 1", "Category 2", "Category 3"]
+    assert groups == ["Category 1 has a very long name", "Category 2", "Category 3"]
 
     data = {
-        "Category 1": ["Chip 1", "Chip 2"],
+        "Category 1 has a very long name": ["Chip 1", "Chip 2"],
         "Category 2": ["Chip 3", "Chip 4"],
         "Category 3": ["Chip 5", "Chip 6", "Chip 7", "Chip 8"],
     }
@@ -160,7 +170,7 @@ def test_chipgroup_toolbar(root_view):
     cat_2_group = [g for g in groups if g.label == "Category 2"][0]
     cat_2_group.remove_chip_by_name("Chip 3")
     data = {
-        "Category 1": ["Chip 1", "Chip 2"],
+        "Category 1 has a very long name": ["Chip 1", "Chip 2"],
         "Category 2": ["Chip 4"],
         "Category 3": ["Chip 5", "Chip 6", "Chip 7", "Chip 8"],
     }
@@ -168,7 +178,7 @@ def test_chipgroup_toolbar(root_view):
 
     cat_2_group.remove_all_chips()
     data = {
-        "Category 1": ["Chip 1", "Chip 2"],
+        "Category 1 has a very long name": ["Chip 1", "Chip 2"],
         "Category 3": ["Chip 5", "Chip 6", "Chip 7", "Chip 8"],
     }
     assert view.chip_group_toolbar.read() == data


### PR DESCRIPTION
 - Fix main root locator.
 - Update fixture data to match current PF4 examples.
 - Fix a bug that prevents raising a 'NoSuchElementException' on calling
   is_displayed on non-displayed ChipGroupToolbar widget.

Add non-existent chip test

add non existent chip widgets