### PR TITLE
[RFR] Add CompoundExpandableTable widget

### DIFF
--- a/src/widgetastic_patternfly4/__init__.py
+++ b/src/widgetastic_patternfly4/__init__.py
@@ -29,6 +29,7 @@ from .select import SelectItemDisabled
 from .select import SelectItemNotFound
 from .switch import Switch
 from .switch import SwitchDisabled
+from .table import CompoundExpandableTable
 from .table import ExpandableTable
 from .table import PatternflyTable
 from .table import RowNotExpandable
@@ -45,6 +46,7 @@ __all__ = [
     "ChipGroupToolbar",
     "ChipGroupToolbarCategory",
     "CompactPagination",
+    "CompoundExpandableTable",
     "StandAloneChipGroup",
     "DonutChart",
     "Dropdown",

--- a/src/widgetastic_patternfly4/__init__.py
+++ b/src/widgetastic_patternfly4/__init__.py
@@ -29,6 +29,7 @@ from .select import SelectItemDisabled
 from .select import SelectItemNotFound
 from .switch import Switch
 from .switch import SwitchDisabled
+from .table import ColumnNotExpandable
 from .table import CompoundExpandableTable
 from .table import ExpandableTable
 from .table import PatternflyTable
@@ -45,6 +46,7 @@ __all__ = [
     "ChipReadOnlyError",
     "ChipGroupToolbar",
     "ChipGroupToolbarCategory",
+    "ColumnNotExpandable",
     "CompactPagination",
     "CompoundExpandableTable",
     "StandAloneChipGroup",

--- a/testing/test_table.py
+++ b/testing/test_table.py
@@ -1,6 +1,9 @@
 import pytest
 from widgetastic.widget import Checkbox
+from widgetastic.widget import View
 
+from widgetastic_patternfly4 import ColumnNotExpandable
+from widgetastic_patternfly4 import CompoundExpandableTable
 from widgetastic_patternfly4 import ExpandableTable
 from widgetastic_patternfly4 import PatternflyTable
 from widgetastic_patternfly4 import RowNotExpandable
@@ -108,3 +111,178 @@ def test_expandable_table(browser):
     assert parent3_row.is_expanded
     assert parent3_row.content.is_displayed
     assert parent3_row.content.read() == row3_expected_content
+
+
+def test_compound_expandable_table(browser):
+    table_read = [
+        {
+            "Repositories": "siemur/test-space",
+            "Branches": "10",
+            "Pull requests": "4",
+            "Workspaces": "4",
+            "Last Commit": "20 minutes",
+            5: "Open in Github",
+        },
+        {
+            "Repositories": "siemur/test-space",
+            "Branches": "3",
+            "Pull requests": "4",
+            "Workspaces": "2",
+            "Last Commit": "20 minutes",
+            5: "Open in Github",
+        },
+    ]
+
+    row0_branches_read = {
+        "table": [
+            {
+                "Repositories": "parent-0",
+                "Branches": "compound-1",
+                "Pull requests": "three",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "a",
+                "Branches": "two",
+                "Pull requests": "k",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "p",
+                "Branches": "two",
+                "Pull requests": "b",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+        ]
+    }
+    row0_pull_requests_read = {
+        "table": [
+            {
+                "Repositories": "parent-0",
+                "Branches": "compound-2",
+                "Pull requests": "three",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "a",
+                "Branches": "two",
+                "Pull requests": "k",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "p",
+                "Branches": "two",
+                "Pull requests": "b",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+        ]
+    }
+    row0_workspaces_read = {
+        "table": [
+            {
+                "Repositories": "parent-0",
+                "Branches": "compound-3",
+                "Pull requests": "three",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "a",
+                "Branches": "two",
+                "Pull requests": "k",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "p",
+                "Branches": "two",
+                "Pull requests": "b",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+        ]
+    }
+    row1_branches_read = {
+        "table": [
+            {
+                "Repositories": "parent-4",
+                "Branches": "compound-1",
+                "Pull requests": "three",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "a",
+                "Branches": "two",
+                "Pull requests": "k",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+            {
+                "Repositories": "p",
+                "Branches": "two",
+                "Pull requests": "b",
+                "Workspaces": "four",
+                "Last Commit": "five",
+            },
+        ]
+    }
+
+    class _ContentView(View):
+        """ View for the nested table(s) in the expandable columns."""
+
+        table = PatternflyTable(locator=".//table[@aria-label='Sortable Table']")
+
+    table = CompoundExpandableTable(
+        browser, ".//table[@aria-label='Compound expandable table']", content_view=_ContentView()
+    )
+
+    assert table.read() == table_read
+
+    # Make sure that the appropriate columns are expandable
+    for row in table.rows():
+        assert not row.repositories.is_expandable
+        assert not row.last_commit.is_expandable
+        assert row.branches.is_expandable
+        assert row.pull_requests.is_expandable
+        assert row.workspaces.is_expandable
+
+    # first column is not an expandable column
+    with pytest.raises(ColumnNotExpandable):
+        table[0][0].expand()
+    with pytest.raises(ColumnNotExpandable):
+        table[1][0].expand()
+
+    # first row
+    row0 = table[0]
+    row0.branches.expand()
+    assert row0.branches.is_expanded
+    assert row0.branches.content.read() == row0_branches_read
+    row0.branches.collapse()
+    assert not row0.branches.is_expanded
+
+    row0.pull_requests.expand()
+    assert row0.pull_requests.is_expanded
+    assert row0.pull_requests.content.read() == row0_pull_requests_read
+    row0.pull_requests.collapse()
+    assert not row0.pull_requests.is_expanded
+
+    row0.workspaces.expand()
+    assert row0.workspaces.is_expanded
+    assert row0.workspaces.content.read() == row0_workspaces_read
+    row0.workspaces.collapse()
+    assert not row0.workspaces.is_expanded
+
+    # second row, just test the first expandable column
+    row1 = table[1]
+    row1.branches.expand()
+    assert row1.branches.is_expanded
+    assert row1.branches.content.read() == row1_branches_read
+    row1.branches.collapse()
+    assert not row1.branches.is_expanded


### PR DESCRIPTION
This widget is meant to cover the React `CompoundExpandableTable` component. 
https://www.patternfly.org/v4/documentation/react/components/table#compound-exandable

There are several key differences between this component/widget and the normal `ExpandableTable` widget that make it difficult to inherit from `ExpandableTable`. The main reason being that, rather than the `row` being the expandable component, the `column` is now the expandable component. The reason for this is that these tables can have an arbitrary number of expandable columns within them. 

Two main limitations exist in this current implementation:
1) It is assumed that the view that appears when each column is expanded is the same regardless of the column
2) It is assumed the the widget used to expand the column is a `button`

These two limitations can potentially be resolved by making use of the `column_widgets` and mapping them with a corresponding `content_views` dict. I think this can be implemented in the future however. 

@bsquizz Can you take a look at this when you get a chance? 