### PR TITLE
RFR: read method for Dropdown

### DIFF
--- a/src/widgetastic_patternfly4/dropdown.py
+++ b/src/widgetastic_patternfly4/dropdown.py
@@ -189,6 +189,9 @@ class Dropdown(Widget):
         """Returns a string of the current dropdown name."""
         return self.browser.text(self.BUTTON_LOCATOR)
 
+    def read(self):
+        return self.button_text
+
     def __repr__(self):
         return "{}({!r})".format(type(self).__name__, getattr(self, "text", None) or self.locator)
 


### PR DESCRIPTION
- `Dropdown` widget need `read` method
-  To use widget as `reference` for `ConditionalSwitchableView`. widget must have `read` method.

Usecase:
```
    find_input_box = ConditionalSwitchableView(reference='column_selector')
    find_input_box.register('Search', default=True, widget=TextInput(locator='.//input[@type="search" or contains(@class, "ins-c-conditional-filter")]'))
    find_input_box.register('Type', widget=CheckboxSelect(locator=".//div[contains(@class, 'pf-c-select') and .//button]"))
    find_input_box.register('Publish date', widget=Select(locator=".//div[contains(@class, 'pf-c-select') and .//button]"))
```
In about code `column_selector` is `Dropdown` widget