### PR TITLE
RFR: SplitButtonDropdown widget

### DIFF
--- a/src/widgetastic_patternfly4/__init__.py
+++ b/src/widgetastic_patternfly4/__init__.py
@@ -13,6 +13,7 @@ from .dropdown import DropdownDisabled
 from .dropdown import DropdownItemDisabled
 from .dropdown import DropdownItemNotFound
 from .dropdown import GroupDropdown
+from .dropdown import SplitButtonDropdown
 from .formselect import FormSelect
 from .formselect import FormSelectDisabled
 from .formselect import FormSelectOptionDisabled
@@ -56,6 +57,7 @@ __all__ = [
     "DropdownItemDisabled",
     "DropdownItemNotFound",
     "GroupDropdown",
+    "SplitButtonDropdown",
     "FormSelect",
     "FormSelectDisabled",
     "FormSelectOptionDisabled",

--- a/src/widgetastic_patternfly4/dropdown.py
+++ b/src/widgetastic_patternfly4/dropdown.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.exceptions import UnexpectedAlertPresentException
 from widgetastic.utils import ParametrizedLocator
+from widgetastic.widget import Checkbox
 from widgetastic.widget import Widget
 from widgetastic.xpath import quote
 
@@ -238,3 +239,28 @@ class GroupDropdown(Dropdown):
             DropdownItemDisabled
         """
         return super().item_select(item, handle_alert=handle_alert, group_name=group_name)
+
+
+class SplitButtonDropdown(Dropdown):
+    """Represents the Patternfly Split Button Dropdown.
+
+    https://www.patternfly.org/v4/documentation/react/components/dropdown#split-button-with-text
+    """
+
+    toggle_check = Checkbox(locator=".//input[@type='checkbox']")
+
+    def check(self):
+        """Check toggle checkbox."""
+        return self.toggle_check.fill(True)
+
+    def uncheck(self):
+        """Uncheck toggle checkbox."""
+        return self.toggle_check.fill(False)
+
+    @property
+    def selected(self):
+        """Returns selected or not"""
+        return self.toggle_check.selected
+
+    def read(self):
+        return self.browser.text(self)

--- a/testing/test_dropdown.py
+++ b/testing/test_dropdown.py
@@ -5,6 +5,7 @@ from widgetastic_patternfly4 import Dropdown
 from widgetastic_patternfly4 import DropdownItemDisabled
 from widgetastic_patternfly4 import DropdownItemNotFound
 from widgetastic_patternfly4 import GroupDropdown
+from widgetastic_patternfly4 import SplitButtonDropdown
 
 
 @pytest.fixture
@@ -33,6 +34,19 @@ def group_dropdown(browser):
             ".//div[@id='ws-react-c-dropdown-with-groups']"
             "/div[contains(@class, 'pf-c-dropdown')]"
         ),
+    )
+
+
+@pytest.fixture(
+    params=["ws-react-c-dropdown-split-button", "ws-react-c-dropdown-split-button-with-text"],
+    ids=["without_text", "with_text"],
+)
+def split_button_dropdown(request, browser):
+    return (
+        SplitButtonDropdown(
+            browser, locator=f".//div[@id='{request.param}']/div[contains(@class, 'pf-c-dropdown')]"
+        ),
+        request.param,
     )
 
 
@@ -95,3 +109,18 @@ def test_group_dropdown(group_dropdown):
     group_dropdown.item_select("Group 3 Link", group_name="Group 3")
     with pytest.raises(DropdownItemNotFound):
         group_dropdown.item_select("Group 3 Link", group_name="Group 2")
+
+
+def test_split_button_dropdown(split_button_dropdown):
+    dropdown, dropdown_type = split_button_dropdown
+    assert dropdown.is_displayed
+    assert dropdown.is_enabled
+    assert dropdown.has_item("Action")
+    dropdown.item_select("Action")
+    assert dropdown.check()
+    assert dropdown.selected
+    expected_text = "10 selected" if "with-text" in dropdown_type else ""
+    assert dropdown.read() == expected_text
+
+    assert dropdown.uncheck()
+    assert not dropdown.selected


### PR DESCRIPTION
https://www.patternfly.org/v4/documentation/react/components/dropdown#split-button-with-text

This widget used with PatternflyTable for bulk entity selection in some plugins. 

This is can  be easily achieved in local view but just adding it in wt.pfy4 as its in component list.
