### PR TITLE
Improve read performance of CheckboxSelect

### DIFF
--- a/src/widgetastic_patternfly4/select.py
+++ b/src/widgetastic_patternfly4/select.py
@@ -1,3 +1,5 @@
+from widgetastic.exceptions import NoSuchElementException
+
 from .dropdown import Dropdown
 from .dropdown import DropdownItemDisabled
 from .dropdown import DropdownItemNotFound
@@ -133,12 +135,14 @@ class CheckboxSelect(Select):
     def read(self):
         """Returns a dictionary containing the selected status as bools."""
         selected = {}
-        try:
-            for item in self._get_items():
-                element = self.item_element(item, close=False)
-                selected[item] = self.browser.is_selected(element)
-        finally:
-            self.close()
+        with self.opened():
+            for el in self.browser.elements(self.ITEMS_LOCATOR):
+                item = self.browser.text(el)
+                try:
+                    # get the child element of the label
+                    selected[item] = el.find_element_by_xpath("./input").is_selected()
+                except NoSuchElementException:
+                    selected[item] = False
 
         return selected
 

--- a/testing/test_select.py
+++ b/testing/test_select.py
@@ -57,8 +57,14 @@ def test_checkbox_select_is_displayed(checkbox_select):
 
 
 def test_checkbox_select_items(checkbox_select):
-    assert set(checkbox_select.items) == {"Active", "Cancelled", "Paused", "Warning", "Restarted"}
-    assert checkbox_select.has_item("Active")
+    assert set(checkbox_select.items) == {
+        "Active This is a description",
+        "Cancelled",
+        "Paused",
+        "Warning",
+        "Restarted",
+    }
+    assert checkbox_select.has_item("Active This is a description")
     assert not checkbox_select.has_item("Non existing item")
     assert checkbox_select.item_enabled("Paused")
 
@@ -74,7 +80,7 @@ def test_checkbox_select_open(checkbox_select):
 def test_checkbox_select_item_checkbox_select(checkbox_select):
     checkbox_select.fill({"Restarted": True, "Cancelled": True})
     assert checkbox_select.read() == {
-        "Active": False,
+        "Active This is a description": False,
         "Cancelled": True,
         "Paused": False,
         "Warning": False,
@@ -82,17 +88,11 @@ def test_checkbox_select_item_checkbox_select(checkbox_select):
     }
 
     checkbox_select.fill(
-        {
-            "Active": False,
-            "Cancelled": False,
-            "Paused": False,
-            "Warning": False,
-            "Restarted": False,
-        }
+        {"Cancelled": False, "Paused": False, "Warning": False, "Restarted": False}
     )
 
     assert checkbox_select.read() == {
-        "Active": False,
+        "Active This is a description": False,
         "Cancelled": False,
         "Paused": False,
         "Warning": False,


### PR DESCRIPTION
I noticed this method takes quite a while to read a checkbox select component. This minor improvement reduces the time to read by about 4x. 

I tested on a `CheckboxSelect` widget with 11 items, and found

| With Changes | Without Changes |
| ---------- | ---------- | 
| 11 s | 47 s |

**Note:** It is not yet possible to perform a fill on a checkbox select item that has a [description](https://patternfly-react.surge.sh/documentation/react/components/select#checkbox-input) (this is why I removed the "Active" field from the `fill` in `test_checkbox_select_item_checkbox_select`). However, this is not due to my changes and should be fixed in a separate PR. 