### PR TITLE
Added OUIA compatibility layer

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         browser: ["firefox", "chrome"]
+        tests: ["testing/ouia/", "testing/"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -34,13 +35,15 @@ jobs:
           pip install -U setuptools pip
           pip install pytest pytest-cov codecov pytest-xdist
           python setup.py install
-      - name: fetch podman image
+      - name: Fetch podman image
         run: podman pull quay.io/redhatqe/selenium-standalone:latest
       - name: Test with pytest
         env:
           BROWSER: ${{ matrix.browser }}
         run: |
-          pytest -v -n 5 --no-cov-on-fail --cov=widgetastic_patternfly4 --cov-report=xml:/tmp/coverage.xml
+          pytest -v -n 5 ${{ matrix.tests }} --no-cov-on-fail \
+                                             --cov=widgetastic_patternfly4 \
+                                             --cov-report=xml:/tmp/coverage.xml
       - name: Publish coverage
         uses: codecov/codecov-action@v1
         with:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = testing/ouia

--- a/src/widgetastic_patternfly4/alert.py
+++ b/src/widgetastic_patternfly4/alert.py
@@ -8,6 +8,7 @@ class Alert(Widget):
     https://www.patternfly.org/v4/documentation/react/components/alert
     """
 
+    PF_NAME = "Alert"
     ROOT = ParametrizedLocator("{@locator}")
     TITLE = './/h4[@class="pf-c-alert__title"]'
     DESCRIPTION = './/div[@class="pf-c-alert__description"]'

--- a/src/widgetastic_patternfly4/breadcrumb.py
+++ b/src/widgetastic_patternfly4/breadcrumb.py
@@ -8,6 +8,7 @@ class BreadCrumb(Widget):
     https://www.patternfly.org/v4/documentation/react/components/breadcrumb
     """
 
+    PF_NAME = "Breadcrumb"
     ROOT = './/nav[contains(@class, "pf-c-breadcrumb")]/ol'
     ELEMENTS = ".//li"
 

--- a/src/widgetastic_patternfly4/button.py
+++ b/src/widgetastic_patternfly4/button.py
@@ -22,6 +22,7 @@ class Button(Widget, ClickableMixin):
         assert not button.disabled
     """
 
+    PF_NAME = "Button"
     ROOT = ParametrizedLocator("{@locator}")
 
     CHECK_VISIBILITY = True

--- a/src/widgetastic_patternfly4/contextselector.py
+++ b/src/widgetastic_patternfly4/contextselector.py
@@ -2,6 +2,8 @@ from .select import Select
 
 
 class ContextSelector(Select):
+
+    PF_NAME = "ContextSelector"
     ITEMS_LOCATOR = ".//ul[@class='pf-c-context-selector__menu-list']/li"
     ITEM_LOCATOR = (
         ".//*[contains(@class, 'pf-c-context-selector__menu-list-item')"

--- a/src/widgetastic_patternfly4/dropdown.py
+++ b/src/widgetastic_patternfly4/dropdown.py
@@ -31,6 +31,7 @@ class Dropdown(Widget):
 
     """
 
+    PF_NAME = "Dropdown"
     ROOT = ParametrizedLocator("{@locator}")
     BUTTON_LOCATOR = ".//button[contains(@class, 'pf-c-dropdown__toggle')]"
     ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-c-dropdown__menu')]/li"

--- a/src/widgetastic_patternfly4/formselect.py
+++ b/src/widgetastic_patternfly4/formselect.py
@@ -27,6 +27,7 @@ class FormSelect(GenericLocatorWidget):
     https://www.patternfly.org/v4/documentation/react/components/formselect
     """
 
+    PF_NAME = "FormSelect"
     ALL_OPTIONS_LOCATOR = ".//option"
     PARENT_OPTION_GROUP = "./parent::optgroup"
 

--- a/src/widgetastic_patternfly4/modal.py
+++ b/src/widgetastic_patternfly4/modal.py
@@ -14,6 +14,7 @@ class Modal(View):
     https://www.patternfly.org/v4/documentation/react/components/modal
     """
 
+    PF_NAME = "ModalContent"
     ROOT = ParametrizedLocator("{@locator}")
     BODY = ".//div[contains(@class, 'pf-c-modal-box__body')]"
     FOOTER = ".//*[contains(@class, 'pf-c-modal-box__footer')]/child::node()"

--- a/src/widgetastic_patternfly4/navigation.py
+++ b/src/widgetastic_patternfly4/navigation.py
@@ -36,22 +36,18 @@ class Navigation(Widget):
     @property
     def loaded(self):
         """Returns a boolean detailing if the nav is loaded."""
-        if self._loaded:
-            return True
-        else:
-            out = self.browser.element(".").get_attribute("data-ouia-safe")
-            if out == "false":
-                self.logger.info("Navigation not ready yet")
-                wait_for(
-                    lambda: self.browser.element(".").get_attribute("data-ouia-safe") == "true",
-                    num_sec=10,
-                )
-            elif not out:
-                self.logger.info("Navigation doesn't have 'data-ouia-safe' property")
-            return True
+        out = self.browser.element(".").get_attribute("data-ouia-safe")
+        if out == "false":
+            self.logger.info("Navigation not ready yet")
+            wait_for(
+                lambda: self.browser.element(".").get_attribute("data-ouia-safe") == "true",
+                num_sec=10,
+            )
+        elif not out:
+            self.logger.info("Navigation doesn't have 'data-ouia-safe' property")
+        return True
 
     def __init__(self, parent, label=None, id=None, locator=None, logger=None):
-        self._loaded = False
         Widget.__init__(self, parent, logger=logger)
 
         quoted_label = quote(label) if label else ""

--- a/src/widgetastic_patternfly4/navigation.py
+++ b/src/widgetastic_patternfly4/navigation.py
@@ -21,6 +21,7 @@ class Navigation(Widget):
     https://www.patternfly.org/v4/documentation/react/components/nav
     """
 
+    PF_NAME = "Nav"
     LOCATOR_START = './/nav[@class="pf-c-nav"{}]'
     ROOT = ParametrizedLocator("{@locator}")
     CURRENTLY_SELECTED = (

--- a/src/widgetastic_patternfly4/optionsmenu.py
+++ b/src/widgetastic_patternfly4/optionsmenu.py
@@ -2,6 +2,7 @@ from .dropdown import Dropdown
 
 
 class OptionsMenu(Dropdown):
+    PF_NAME = "OptionsMenu"
     BUTTON_LOCATOR = (
         ".//button[contains(@class, 'pf-c-options-menu__toggle') or "
         "contains(@class, 'pf-c-options-menu__toggle-button')]"

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+
+from widgetastic.utils import ParametrizedLocator
+
+
+class OUIAMixin:
+
+    ROOT = ParametrizedLocator(
+        './/*[@data-ouia-component-type="PF4/{@component_type}" and '
+        '@data-ouia-component-id="{@component_id}"]'
+    )
+
+    def __init__(self, component_type, component_id):
+        self.component_type = component_type
+        self.component_id = component_id
+
+    @property
+    def is_safe(self):
+        return "true" in self.browser.get_attribute("data-ouia-safe", self)
+
+
+class ImportHack:
+    def __getattr__(self, name):
+        if name.endswith("OUIA"):
+            return self.generate_ouia_compat_widget(name)
+
+    def generate_ouia_compat_widget(self, name):
+        klass_name = name.rstrip("OUIA")
+        module = importlib.import_module("widgetastic_patternfly4")
+        klass = getattr(module, klass_name)
+        if not hasattr(klass, "PF_NAME"):
+            raise ImportError(f"{klass_name} is not OUIA ready")
+
+        class WidgetWithOUIA(klass, OUIAMixin):
+            def __init__(self, parent, component_id, logger=None, *args, **kwargs):
+                klass.ROOT = OUIAMixin.ROOT
+                OUIAMixin.__init__(self, klass.PF_NAME, component_id)
+                super(klass, self).__init__(parent, logger=logger)
+
+        WidgetWithOUIA.__name__ = WidgetWithOUIA.__qualname__ = name
+        return WidgetWithOUIA
+
+
+sys.modules[__name__] = ImportHack()

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -3,9 +3,11 @@ import sys
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import GenericLocatorWidget
 from widgetastic.widget import Table
+from widgetastic.widget import Widget
 from widgetastic.xpath import quote
 
 import widgetastic_patternfly4
+from .dropdown import Dropdown
 
 
 class OUIAMixin:
@@ -35,14 +37,14 @@ def generate_ouia_compat_class(name):
         raise ValueError(f"{klass_name} is not OUIA ready")
 
     class WidgetWithOUIA(OUIAMixin, klass):
-        klass.ROOT = OUIAMixin.ROOT
-
         def __init__(self, parent, component_id, logger=None, *args, **kwargs):
             OUIAMixin.__init__(self, klass.PF_NAME, component_id)
             if issubclass(klass, GenericLocatorWidget):
                 super(klass, self).__init__(parent, self.locator, logger=logger)
             elif issubclass(klass, Table):
                 super(klass, self).__init__(parent, self.locator, logger=logger, **kwargs)
+            elif issubclass(klass, Dropdown):
+                Widget.__init__(self, parent, logger=logger)
             else:
                 super(klass, self).__init__(parent, logger=logger)
 

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -1,6 +1,7 @@
 import sys
 
 from widgetastic.utils import ParametrizedLocator
+from widgetastic.widget import GenericLocatorWidget
 from widgetastic.xpath import quote
 
 import widgetastic_patternfly4
@@ -37,7 +38,10 @@ def generate_ouia_compat_class(name):
 
         def __init__(self, parent, component_id, logger=None, *args, **kwargs):
             OUIAMixin.__init__(self, klass.PF_NAME, component_id)
-            super(klass, self).__init__(parent, logger=logger)
+            if issubclass(klass, GenericLocatorWidget):
+                super(klass, self).__init__(parent, self.locator, logger=logger)
+            else:
+                super(klass, self).__init__(parent, logger=logger)
 
     WidgetWithOUIA.__name__ = WidgetWithOUIA.__qualname__ = name
     return WidgetWithOUIA

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -2,6 +2,7 @@ import sys
 
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import GenericLocatorWidget
+from widgetastic.widget import Table
 from widgetastic.xpath import quote
 
 import widgetastic_patternfly4
@@ -40,6 +41,8 @@ def generate_ouia_compat_class(name):
             OUIAMixin.__init__(self, klass.PF_NAME, component_id)
             if issubclass(klass, GenericLocatorWidget):
                 super(klass, self).__init__(parent, self.locator, logger=logger)
+            elif issubclass(klass, Table):
+                super(klass, self).__init__(parent, self.locator, logger=logger, **kwargs)
             else:
                 super(klass, self).__init__(parent, logger=logger)
 

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -1,6 +1,7 @@
 import sys
 
 from widgetastic.utils import ParametrizedLocator
+from widgetastic.xpath import quote
 
 import widgetastic_patternfly4
 
@@ -8,13 +9,14 @@ import widgetastic_patternfly4
 class OUIAMixin:
 
     ROOT = ParametrizedLocator(
-        './/*[@data-ouia-component-type="PF4/{@component_type}" and '
-        '@data-ouia-component-id="{@component_id}"]'
+        ".//*[@data-ouia-component-type={@component_type} and "
+        "@data-ouia-component-id={@component_id}]"
     )
 
     def __init__(self, component_type, component_id):
-        self.component_type = component_type
-        self.component_id = component_id
+        self.component_type = quote(f"PF4/{component_type}")
+        self.component_id = quote(component_id)
+        self.locator = self.ROOT.locator
 
     @property
     def is_safe(self):

--- a/src/widgetastic_patternfly4/pagination.py
+++ b/src/widgetastic_patternfly4/pagination.py
@@ -41,7 +41,14 @@ class Pagination(View):
         if not locator:
             locator = self.DEFAULT_LOCATOR
         self.locator = locator
-        self._cached_per_page_value = None
+
+    @property
+    def cached_per_page_value(self):
+        return getattr(self, "_cached_per_page_value", None)
+
+    @cached_per_page_value.setter
+    def cached_per_page_value(self, value):
+        self._cached_per_page_value = value
 
     @property
     def is_first_disabled(self):
@@ -126,8 +133,8 @@ class Pagination(View):
     @property
     def current_per_page(self):
         """Returns an integer detailing how many items are shown per page."""
-        if self._cached_per_page_value:
-            return self._cached_per_page_value
+        if self.cached_per_page_value:
+            return self.cached_per_page_value
 
         if self.no_items:
             return 0
@@ -143,10 +150,10 @@ class Pagination(View):
         assume that the "per page" setting is not going to change and it's not necessary to
         re-read it from the browser repeatedly.
         """
-        self._cached_per_page_value = None
-        self._cached_per_page_value = self.current_per_page
+        self.cached_per_page_value = None
+        self.cached_per_page_value = self.current_per_page
         yield
-        self._cached_per_page_value = None
+        self.cached_per_page_value = None
 
     def set_per_page(self, count):
         """Sets the number of items per page. (Will cast to str)"""

--- a/src/widgetastic_patternfly4/pagination.py
+++ b/src/widgetastic_patternfly4/pagination.py
@@ -21,6 +21,7 @@ class Pagination(View):
     https://www.patternfly.org/v4/documentation/react/components/pagination
     """
 
+    PF_NAME = "Pagination"
     ROOT = ParametrizedLocator("{@locator}")
     DEFAULT_LOCATOR = (
         ".//div[contains(@class, 'pf-c-pagination') and not(contains(@class, 'pf-m-compact'))]"

--- a/src/widgetastic_patternfly4/select.py
+++ b/src/widgetastic_patternfly4/select.py
@@ -19,6 +19,7 @@ class Select(Dropdown):
     https://www.patternfly.org/v4/documentation/react/components/select
     """
 
+    PF_NAME = "Select"
     BUTTON_LOCATOR = "./button"
     ITEMS_LOCATOR = ".//ul[@class='pf-c-select__menu']/li"
     ITEM_LOCATOR = ".//*[contains(@class, 'pf-c-select__menu-item') and normalize-space(.)={}]"

--- a/src/widgetastic_patternfly4/switch.py
+++ b/src/widgetastic_patternfly4/switch.py
@@ -12,6 +12,7 @@ class Switch(GenericLocatorWidget):
     https://www.patternfly.org/v4/documentation/react/components/switch
     """
 
+    PF_NAME = "Switch"
     CHECKBOX_LOCATOR = "./input"
     LABEL_ON = "./span[contains(@class, 'pf-m-on')]"
     LABEL_OFF = "./span[contains(@class, 'pf-m-off')]"

--- a/src/widgetastic_patternfly4/table.py
+++ b/src/widgetastic_patternfly4/table.py
@@ -101,6 +101,7 @@ class PatternflyTable(Table):
     https://www.patternfly.org/v4/documentation/react/components/table
     """
 
+    PF_NAME = "Table"
     ROWS = "./tbody/tr[./td]"
     HEADERS = "./thead/tr/th|./tr/th|./thead/tr/td"
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -59,7 +59,7 @@ def selenium_url(pytestconfig, worker_id):
 
         yield f"http://{host}:4444/wd/hub"
         container_id = ps.stdout.decode("utf-8").strip()
-        subprocess.run(["podman", "kill", container_id])
+        subprocess.run(["podman", "kill", container_id], stdout=subprocess.DEVNULL)
     else:
         yield f"http://{forced_host}:4444/wd/hub"
 
@@ -85,14 +85,16 @@ def browser(selenium, request):
     try:
         page = module.SUBPAGE
     except AttributeError:
-
         page = name = module.__name__.split("_")[1]
         category = getattr(module, "CATEGORY", "components")
         page = f"{category}/{name}"
 
     name = request.module.__name__.split("_")[1]
     category = getattr(request.module, "CATEGORY", "components")
-    url = f"https://patternfly-react.surge.sh/documentation/react/{page}"
+    if "ouia" in request.module.__file__:
+        url = f"https://patternfly-docs-ouia.netlify.app/documentation/react/{page}"
+    else:
+        url = f"https://patternfly-react.surge.sh/documentation/react/{page}"
     selenium.maximize_window()
     selenium.get(url)
     return Browser(selenium)

--- a/testing/ouia/test_alert.py
+++ b/testing/ouia/test_alert.py
@@ -1,0 +1,26 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import AlertOUIA
+
+
+ALERT_TYPES = ["success", "danger", "warning", "info"]
+
+
+@pytest.fixture(params=ALERT_TYPES)
+def alert(browser, request):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-alert-ouia']"
+        alert = AlertOUIA(request.param)
+
+    view = TestView(browser)
+    return view.alert
+
+
+def test_alert_is_displayed(alert):
+    assert alert.is_displayed
+
+
+def test_alert_title(alert):
+    alert_type = alert.type if alert.type != "error" else "danger"
+    assert alert.title == f"{alert_type.capitalize()} alert title"

--- a/testing/ouia/test_breadcrumb.py
+++ b/testing/ouia/test_breadcrumb.py
@@ -1,0 +1,40 @@
+import re
+
+import pytest
+from widgetastic.exceptions import WidgetOperationFailed
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import BreadCrumbOUIA
+
+
+def test_breadcrumb(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-breadcrumb-ouia']"
+        breadcrumb = BreadCrumbOUIA("basic")
+
+    view = TestView(browser)
+    assert view.breadcrumb.is_displayed
+    assert len(view.breadcrumb.locations) == 4
+    assert view.breadcrumb.locations[0].lower() == "section home"
+    assert view.breadcrumb.read().lower() == "section landing"
+    view.breadcrumb.click_location(view.breadcrumb.locations[0])
+    view.breadcrumb.click_location("title", partial=True)
+
+    failing_location = "definitely not in the example page"
+
+    # exception + message on full match
+    exception_match = re.escape(
+        f'Breadcrumb location "{failing_location}" '
+        f"not found within locations: {view.breadcrumb.locations}"
+    )
+    with pytest.raises(WidgetOperationFailed, match=exception_match):
+        view.breadcrumb.click_location(failing_location)
+
+    # exception + message on partial match
+    exception_match = re.escape(
+        f'Breadcrumb location "{failing_location}" '
+        "not found with partial match "
+        f"within locations: {view.breadcrumb.locations}"
+    )
+    with pytest.raises(WidgetOperationFailed, match=exception_match):
+        view.breadcrumb.click_location(failing_location, partial=True)

--- a/testing/ouia/test_button.py
+++ b/testing/ouia/test_button.py
@@ -1,0 +1,18 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import ButtonOUIA
+
+
+@pytest.fixture
+def view(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-button-ouia']"
+        button = ButtonOUIA("Primary")
+
+    return TestView(browser)
+
+
+def test_button_click(view):
+    assert view.button.is_displayed
+    view.button.click()

--- a/testing/ouia/test_contextselector.py
+++ b/testing/ouia/test_contextselector.py
@@ -1,0 +1,51 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import SelectItemNotFound
+from widgetastic_patternfly4.ouia import ContextSelectorOUIA
+
+
+@pytest.fixture
+def view(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-contextselector-ouia']"
+        contextselector = ContextSelectorOUIA("Basic")
+
+    return TestView(browser)
+
+
+def test_contextselector_is_displayed(view):
+    assert view.contextselector.is_displayed
+
+
+def test_contextselector_items(view):
+    assert set(view.contextselector.items) == {
+        "My Project",
+        "OpenShift Cluster",
+        "Production Ansible",
+        "AWS",
+        "Azure",
+        "My Project 2",
+        "Production Ansible 2",
+        "AWS 2",
+        "Azure 2",
+    }
+    assert view.contextselector.has_item("AWS")
+    assert not view.contextselector.has_item("Non existing item")
+
+
+def test_contextselector_open(view):
+    assert not view.contextselector.is_open
+    view.contextselector.open()
+    assert view.contextselector.is_open
+    view.contextselector.close()
+    assert not view.contextselector.is_open
+
+
+def test_contextselector_item_select(view):
+    view.contextselector.fill("AWS")
+    assert view.contextselector.read() == "AWS"
+    assert not view.contextselector.is_open
+    with pytest.raises(SelectItemNotFound):
+        view.contextselector.fill("Non existing item")
+    assert not view.contextselector.is_open

--- a/testing/ouia/test_dropdown.py
+++ b/testing/ouia/test_dropdown.py
@@ -1,0 +1,57 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import DropdownItemDisabled
+from widgetastic_patternfly4 import DropdownItemNotFound
+from widgetastic_patternfly4.ouia import DropdownOUIA
+
+
+@pytest.fixture
+def dropdown(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-dropdown-ouia']"
+        dropdown = DropdownOUIA("Dropdown")
+
+    view = TestView(browser)
+    return view.dropdown
+
+
+def test_dropdown_is_displayed(dropdown):
+    assert dropdown.is_displayed
+
+
+def test_enabled_dropdown(dropdown):
+    assert dropdown.is_enabled
+
+
+def test_dropdown_items(dropdown):
+    assert dropdown.items == [
+        "Link",
+        "Action",
+        "Disabled Link",
+        "Disabled Action",
+        "",
+        "Separated Link",
+        "Separated Action",
+    ]
+    assert dropdown.has_item("Action")
+    assert not dropdown.has_item("Non existing items")
+    assert dropdown.item_enabled("Action")
+    assert not dropdown.item_enabled("Disabled Link")
+
+
+def test_dropdown_open(dropdown):
+    assert not dropdown.is_open
+    dropdown.open()
+    assert dropdown.is_open
+    dropdown.close()
+    assert not dropdown.is_open
+
+
+def test_dropdown_item_select(dropdown):
+    dropdown.item_select("Action")
+    assert not dropdown.is_open
+    with pytest.raises(DropdownItemDisabled):
+        dropdown.item_select("Disabled Link")
+    with pytest.raises(DropdownItemNotFound):
+        dropdown.item_select("Non existing items")

--- a/testing/ouia/test_formselect.py
+++ b/testing/ouia/test_formselect.py
@@ -1,0 +1,47 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import FormSelectOptionNotFound
+from widgetastic_patternfly4.ouia import FormSelectOUIA
+
+
+class FormSelectTestView(View):
+    ROOT = ".//div[@id='ws-react-c-formselect-ouia']"
+    input = FormSelectOUIA("FormSelect Input")
+
+
+@pytest.fixture
+def view(browser):
+    return FormSelectTestView(browser)
+
+
+def test_formselect_visibility(view):
+    assert view.input.is_displayed
+
+
+def test_formselect_enablement(view):
+    assert view.input.is_enabled
+
+
+def test_formselect_validity(view):
+    assert view.input.is_valid
+
+
+def test_formselect_value(view):
+    assert len(view.input.all_options) == 7
+    assert len(view.input.all_enabled_options) == 6
+    assert "Mrs" in view.input.all_options
+    view.input.fill("Mrs")
+    assert view.input.read() == "Mrs"
+
+
+def test_formselect_option_enablement(view):
+    expected_enabled_options = {"Mr", "Miss", "Mrs", "Ms", "Dr", "Other"}
+    expected_disabled_options = {"Please Choose"}
+    assert set(view.input.all_enabled_options) == expected_enabled_options
+    assert expected_disabled_options not in set(view.input.all_enabled_options)
+
+
+def test_formselect_fill_nonexistent_option(view):
+    with pytest.raises(FormSelectOptionNotFound):
+        view.input.fill("foo")

--- a/testing/ouia/test_formselect.py
+++ b/testing/ouia/test_formselect.py
@@ -5,13 +5,12 @@ from widgetastic_patternfly4 import FormSelectOptionNotFound
 from widgetastic_patternfly4.ouia import FormSelectOUIA
 
 
-class FormSelectTestView(View):
-    ROOT = ".//div[@id='ws-react-c-formselect-ouia']"
-    input = FormSelectOUIA("FormSelect Input")
-
-
 @pytest.fixture
 def view(browser):
+    class FormSelectTestView(View):
+        ROOT = ".//div[@id='ws-react-c-formselect-ouia']"
+        input = FormSelectOUIA("FormSelect Input")
+
     return FormSelectTestView(browser)
 
 

--- a/testing/ouia/test_modal.py
+++ b/testing/ouia/test_modal.py
@@ -1,0 +1,71 @@
+import pytest
+from widgetastic.widget import Text
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.modal import ModalItemNotFound
+from widgetastic_patternfly4.ouia import ButtonOUIA
+from widgetastic_patternfly4.ouia import ModalOUIA
+
+
+@pytest.fixture()
+def modal(browser):
+    class ModalTestView(View):
+        ROOT = ".//div[@id='ws-react-c-modal-ouia']"
+        show_modal = ButtonOUIA("Show Modal")
+
+    modal = ModalOUIA(browser, "Simple modal")
+
+    view = ModalTestView(browser)
+    view.show_modal.click()
+    yield modal
+    if modal.is_displayed:
+        modal.close()
+
+
+class CustomModal(ModalOUIA):
+    """Model use as view and enhance with widgets"""
+
+    custom_body = Text(".//div[contains(@class, 'pf-c-modal-box__body')]")
+
+
+def test_title(modal):
+    assert modal.title
+
+
+def test_body(modal):
+    body = modal.body
+    assert body.text.startswith("Lorem")
+
+
+def test_close(modal):
+    modal.close()
+    assert not modal.is_displayed
+
+
+def test_footer_items(modal):
+    items = modal.footer_items
+    assert len(items) == 2
+    assert "Cancel" in items
+    assert "Confirm" in items
+
+
+def test_footer_item(modal):
+    item = modal.footer_item("Confirm")
+    assert item.text == "Confirm"
+    item.click()
+    assert not modal.is_displayed
+
+
+def test_footer_item_invalid(modal):
+    try:
+        modal.footer_item("INVALID")
+    except ModalItemNotFound:
+        assert True
+    else:
+        pytest.fail("ModalItemNotFound exception expected.")
+
+
+def test_modal_as_view(browser, modal):
+    view = CustomModal(browser, "Simple modal")
+    assert view.is_displayed
+    assert view.custom_body.text == modal.body.text

--- a/testing/ouia/test_nav.py
+++ b/testing/ouia/test_nav.py
@@ -1,0 +1,18 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import NavigationOUIA
+
+
+@pytest.fixture
+def view(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-nav-ouia']"
+        nav = NavigationOUIA("Nav Default")
+
+    return TestView(browser)
+
+
+def test_navigation(browser, view):
+    assert view.nav.currently_selected == ["Link 1"]
+    assert view.nav.nav_item_tree() == ["Link 1", "Link 2", "Link 3", "Link 4"]

--- a/testing/ouia/test_optionsmenu.py
+++ b/testing/ouia/test_optionsmenu.py
@@ -1,0 +1,45 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import DropdownItemNotFound
+from widgetastic_patternfly4.ouia import OptionsMenuOUIA
+
+
+@pytest.fixture
+def options_menu(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-optionsmenu-ouia']"
+        options_menu = OptionsMenuOUIA("Simple Options Menu")
+
+    return TestView(browser).options_menu
+
+
+def test_options_menu_is_displayed(options_menu):
+    assert options_menu.is_displayed
+
+
+def test_enabled_options_menu(options_menu):
+    assert options_menu.is_enabled
+
+
+def test_options_menu_items(options_menu):
+    assert options_menu.items == ["Option 1", "Option 2", "Option 3"]
+    assert options_menu.has_item("Option 2")
+    assert not options_menu.has_item("Non existing items")
+    assert options_menu.item_enabled("Option 1")
+
+
+def test_options_menu_open(options_menu):
+    assert not options_menu.is_open
+    options_menu.open()
+    assert options_menu.is_open
+    options_menu.close()
+    assert not options_menu.is_open
+
+
+def test_options_menu_item_select(options_menu):
+    options_menu.item_select("Option 2")
+    assert options_menu.selected_items[0] == "Option 2"
+    assert not options_menu.is_open
+    with pytest.raises(DropdownItemNotFound):
+        options_menu.item_select("Non existing items")

--- a/testing/ouia/test_pagination.py
+++ b/testing/ouia/test_pagination.py
@@ -1,0 +1,125 @@
+import pytest
+from wait_for import wait_for
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import PaginationNavDisabled
+from widgetastic_patternfly4.ouia import PaginationOUIA
+
+
+# Locates a paginator under a specific header
+LOCATOR = ".//div[@id='ws-react-c-pagination-{}']/div[contains(@class, 'pf-c-pagination')]"
+
+
+class TestView(View):
+    ROOT = ".//div[@id='ws-react-c-pagination-ouia']"
+    paginator = PaginationOUIA("pagination-options-menu-top")
+
+
+@pytest.fixture
+def paginator(browser, request):
+    paginator = TestView(browser).paginator
+    wait_for(lambda: paginator.is_displayed, num_sec=10)
+    yield paginator
+    try:
+        paginator.first_page()
+    except PaginationNavDisabled:
+        # We are already at the first page...
+        pass
+
+
+def test_first_page(paginator):
+    paginator.last_page()
+    assert paginator.current_page == 27
+    paginator.first_page()
+    assert paginator.is_first_disabled
+    assert paginator.is_previous_disabled
+    assert not paginator.is_next_disabled
+    assert not paginator.is_last_disabled
+    assert paginator.current_page == 1
+    assert paginator.total_pages == 27
+    assert paginator.displayed_items == (1, 20)
+    assert paginator.total_items == 523
+
+
+def test_previous_page(paginator):
+    paginator.next_page()
+    assert paginator.current_page == 2
+    paginator.previous_page()
+    assert not paginator.is_next_disabled
+    assert not paginator.is_last_disabled
+    assert paginator.current_page == 1
+    assert paginator.total_pages == 27
+    assert paginator.displayed_items == (1, 20)
+    assert paginator.total_items == 523
+
+
+def test_next_page(paginator):
+    paginator.next_page()
+    assert not paginator.is_first_disabled
+    assert not paginator.is_previous_disabled
+    assert not paginator.is_next_disabled
+    assert not paginator.is_last_disabled
+    assert paginator.current_page == 2
+    assert paginator.total_pages == 27
+    assert paginator.displayed_items == (21, 40)
+    assert paginator.total_items == 523
+
+
+def test_last_page(paginator):
+    paginator.last_page()
+    assert not paginator.is_first_disabled
+    assert not paginator.is_previous_disabled
+    assert paginator.is_next_disabled
+    assert paginator.is_last_disabled
+    assert paginator.current_page == 27
+    assert paginator.total_pages == 27
+    assert paginator.displayed_items == (521, 523)
+    assert paginator.total_items == 523
+
+
+def test_per_page_options(paginator):
+    assert paginator.per_page_options == [
+        "10 per page",
+        "20 per page",
+        "50 per page",
+        "100 per page",
+    ]
+
+
+@pytest.mark.parametrize("items_per_page", [50, 100])
+def test_iteration(paginator, items_per_page):
+    assert paginator.is_first_disabled
+    paginator.set_per_page(items_per_page)
+    assert paginator.current_per_page == items_per_page
+
+    # Ensure we're always using an int for the math calculations
+    items_per_page_int = int(str(items_per_page).split()[0])
+
+    expected_total_pages = 523 // items_per_page_int + 1
+    assert paginator.is_previous_disabled
+    with paginator.cache_per_page_value():
+        for page in paginator:
+            assert paginator.current_page == page
+            assert paginator.total_pages == expected_total_pages
+            if items_per_page_int * page > paginator.total_items:
+                right_number = paginator.total_items
+            else:
+                right_number = items_per_page_int * page
+            assert paginator.displayed_items == (1 + items_per_page_int * (page - 1), right_number)
+            assert paginator.total_items == 523
+    assert paginator.is_next_disabled
+    assert paginator.is_last_disabled
+
+
+def test_bad_paginator_page_value(paginator):
+    with pytest.raises(ValueError):
+        paginator.set_per_page(9999999)
+    with pytest.raises(ValueError):
+        paginator.set_per_page("999999")
+
+
+def test_custom_page(paginator):
+    disp_items = paginator.displayed_items
+    paginator.go_to_page(2)
+    assert paginator.current_page == 2
+    assert disp_items != paginator.displayed_items

--- a/testing/ouia/test_pagination.py
+++ b/testing/ouia/test_pagination.py
@@ -6,17 +6,12 @@ from widgetastic_patternfly4 import PaginationNavDisabled
 from widgetastic_patternfly4.ouia import PaginationOUIA
 
 
-# Locates a paginator under a specific header
-LOCATOR = ".//div[@id='ws-react-c-pagination-{}']/div[contains(@class, 'pf-c-pagination')]"
-
-
-class TestView(View):
-    ROOT = ".//div[@id='ws-react-c-pagination-ouia']"
-    paginator = PaginationOUIA("pagination-options-menu-top")
-
-
 @pytest.fixture
 def paginator(browser, request):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-pagination-ouia']"
+        paginator = PaginationOUIA("pagination-options-menu-top")
+
     paginator = TestView(browser).paginator
     wait_for(lambda: paginator.is_displayed, num_sec=10)
     yield paginator

--- a/testing/ouia/test_select.py
+++ b/testing/ouia/test_select.py
@@ -1,0 +1,43 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import SelectItemNotFound
+from widgetastic_patternfly4.ouia import SelectOUIA
+
+
+class TestView(View):
+    ROOT = ".//div[@id='ws-react-c-select-ouia']"
+    select = SelectOUIA("Single")
+
+
+@pytest.fixture
+def select(browser):
+    return TestView(browser).select
+
+
+def test_select_is_displayed(select):
+    assert select.is_displayed
+
+
+def test_select_items(select):
+    assert set(select.items) == {"Choose...", "Mr", "Miss", "Mrs", "Ms", "Dr", "Other"}
+    assert select.has_item("Mr")
+    assert not select.has_item("Non existing item")
+    assert select.item_enabled("Miss")
+
+
+def test_select_open(select):
+    assert not select.is_open
+    select.open()
+    assert select.is_open
+    select.close()
+    assert not select.is_open
+
+
+def test_select_item_select(select):
+    select.fill("Mr")
+    assert select.read() == "Mr"
+    assert not select.is_open
+    with pytest.raises(SelectItemNotFound):
+        select.fill("Non existing item")
+    assert not select.is_open

--- a/testing/ouia/test_select.py
+++ b/testing/ouia/test_select.py
@@ -5,13 +5,12 @@ from widgetastic_patternfly4 import SelectItemNotFound
 from widgetastic_patternfly4.ouia import SelectOUIA
 
 
-class TestView(View):
-    ROOT = ".//div[@id='ws-react-c-select-ouia']"
-    select = SelectOUIA("Single")
-
-
 @pytest.fixture
 def select(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-select-ouia']"
+        select = SelectOUIA("Single")
+
     return TestView(browser).select
 
 

--- a/testing/ouia/test_switch.py
+++ b/testing/ouia/test_switch.py
@@ -1,0 +1,43 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import SwitchOUIA
+
+
+@pytest.fixture
+def view(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-switch-ouia']"
+        switch = SwitchOUIA("Simple Switch")
+
+    return TestView(browser)
+
+
+def test_switch_is_displayed(view):
+    assert view.switch.is_displayed
+
+
+def test_switch_is_enabled(view):
+    assert view.switch.is_enabled
+
+
+def test_switch_label(view):
+    assert view.switch.label == "Message when on"
+
+
+def test_switch_selected(view):
+    assert view.switch.read()
+
+
+def test_switch_fill(view):
+    assert view.switch.selected
+    assert view.switch.label == "Message when on"
+    assert not view.switch.fill(True)
+    assert view.switch.selected
+    assert view.switch.label == "Message when on"
+    assert view.switch.fill(False)
+    assert not view.switch.selected
+    assert view.switch.label == "Message when off"
+    assert view.switch.fill(True)
+    assert view.switch.selected
+    assert view.switch.label == "Message when on"

--- a/testing/ouia/test_table.py
+++ b/testing/ouia/test_table.py
@@ -12,14 +12,14 @@ SORT = [
 ]
 
 
-class TestView(View):
-    ROOT = ".//div[@id='ws-react-c-table-ouia']"
-    table = PatternflyTableOUIA("Sortable Table")
-
-
 @pytest.mark.parametrize("sample", SORT, ids=lambda sample: "{}-{}".format(sample[0], sample[1]))
 def test_sortable_table(browser, sample):
     header, order, expected_result = sample
+
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-c-table-ouia']"
+        table = PatternflyTableOUIA("Sortable Table")
+
     view = TestView(browser)
     view.table.sort_by(header, order)
     column = [row[header] for row in view.table.read()]

--- a/testing/ouia/test_table.py
+++ b/testing/ouia/test_table.py
@@ -1,0 +1,26 @@
+import pytest
+from widgetastic.widget import View
+
+from widgetastic_patternfly4.ouia import PatternflyTableOUIA
+
+
+SORT = [
+    ("Repositories", "ascending", ["a", "one", "p"]),
+    ("Repositories", "descending", ["p", "one", "a"]),
+    ("Pull requests", "ascending", ["a", "b", "k"]),
+    ("Pull requests", "descending", ["k", "b", "a"]),
+]
+
+
+class TestView(View):
+    ROOT = ".//div[@id='ws-react-c-table-ouia']"
+    table = PatternflyTableOUIA("Sortable Table")
+
+
+@pytest.mark.parametrize("sample", SORT, ids=lambda sample: "{}-{}".format(sample[0], sample[1]))
+def test_sortable_table(browser, sample):
+    header, order, expected_result = sample
+    view = TestView(browser)
+    view.table.sort_by(header, order)
+    column = [row[header] for row in view.table.read()]
+    assert column == expected_result

--- a/testing/test_alert.py
+++ b/testing/test_alert.py
@@ -1,7 +1,6 @@
 import pytest
 
 from widgetastic_patternfly4 import Alert
-from widgetastic_patternfly4.ouia import AlertOUIA
 
 
 ALERT_TYPES = ["success", "danger", "warning", "info"]
@@ -19,8 +18,3 @@ def test_alert_is_displayed(alert):
 def test_alert_title(alert):
     alert_type = alert.type if alert.type != "error" else "danger"
     assert alert.title == f"{alert_type.capitalize()} alert title"
-
-
-def test_alert_ouia(browser):
-    alert = AlertOUIA(browser, "633")
-    assert alert.is_displayed

--- a/testing/test_alert.py
+++ b/testing/test_alert.py
@@ -1,6 +1,7 @@
 import pytest
 
 from widgetastic_patternfly4 import Alert
+from widgetastic_patternfly4.ouia import AlertOUIA
 
 
 ALERT_TYPES = ["success", "danger", "warning", "info"]
@@ -18,3 +19,8 @@ def test_alert_is_displayed(alert):
 def test_alert_title(alert):
     alert_type = alert.type if alert.type != "error" else "danger"
     assert alert.title == f"{alert_type.capitalize()} alert title"
+
+
+def test_alert_ouia(browser):
+    alert = AlertOUIA(browser, "633")
+    assert alert.is_displayed


### PR DESCRIPTION
This PR adds OUIA compatibility layer to some widgets of wt.pf4. How to use it? Just import the existing widget by adding `OUIA`. E.g.:

```python
from widgetastic_patternfly4.ouia import AlertOUIA

def test_alert_ouia(browser):
    alert = AlertOUIA(browser, "some_meaningful_id")
    assert alert.is_displayed
```

OUIA widgets accept only two arguments: an instance of `widgetastic.browser.Browser` and `data-component-ouia-id`.   `data-component-ouia-id` is described in OUIA specification.