### PR TITLE
Fix referencing navigation items with trailing spaces

### DIFF
--- a/src/widgetastic_patternfly4/navigation.py
+++ b/src/widgetastic_patternfly4/navigation.py
@@ -76,7 +76,9 @@ class Navigation(Widget):
             return [el.get_property("textContent") for el in self.browser.elements(self.ITEMS)]
         current_item = self
         for i, level in enumerate(levels):
-            li = self.browser.element(self.ITEM_MATCHING.format(quote(level)), parent=current_item)
+            li = self.browser.element(
+                self.ITEM_MATCHING.format(quote(level.strip())), parent=current_item
+            )
 
             try:
                 current_item = self.browser.element(self.SUB_ITEMS_ROOT, parent=li)


### PR DESCRIPTION
In cloud.redhat.com there is a link to documentation in the navigation which includes an icon. In order to provide some whitespace between the text and the icon, the developers added a space between the word and the icon. This space results in the text containing a trailing space.

This causes a problem when looking up the navigation element, as the XPath strips the trailing space, causing an ElementNotFound exception. This PR fixes the problem.

![documentation-space](https://user-images.githubusercontent.com/1080682/97355733-8bff0e80-1854-11eb-8147-c9e0807d8b39.png)
