### PR TITLE
Updates to Navigation Widget

### DIFF
--- a/src/widgetastic_patternfly4/__init__.py
+++ b/src/widgetastic_patternfly4/__init__.py
@@ -27,6 +27,7 @@ from .formselect import FormSelectOptionDisabled
 from .formselect import FormSelectOptionNotFound
 from .modal import Modal
 from .navigation import Navigation
+from .navigation import NavSelectionNotFound
 from .optionsmenu import OptionsMenu
 from .pagination import CompactPagination
 from .pagination import Pagination
@@ -80,6 +81,7 @@ __all__ = [
     "FormSelectOptionNotFound",
     "Modal",
     "Navigation",
+    "NavSelectionNotFound",
     "OptionsMenu",
     "Pagination",
     "PaginationNavDisabled",

--- a/src/widgetastic_patternfly4/navigation.py
+++ b/src/widgetastic_patternfly4/navigation.py
@@ -15,6 +15,10 @@ def check_nav_loaded(fn):
     return inner
 
 
+class NavSelectionNotFound(Exception):
+    pass
+
+
 class BaseNavigation:
     """The Patternfly navigation.
 
@@ -28,7 +32,6 @@ class BaseNavigation:
     ITEMS = "./ul/li/*[self::a or self::button]"
     SUB_ITEMS_ROOT = "./section"
     ITEM_MATCHING = "./ul/li[.//*[self::a or self::button][normalize-space(.)={}]]"
-    ITEM_MATCHING_OUIA = "./ul/li[@ouia-nav-group={text} or .//a[@ouia-nav-item={text}]]"
 
     @property
     def loaded(self):
@@ -112,8 +115,9 @@ class BaseNavigation:
                     self.ITEM_MATCHING.format(quote(level)), parent=current_item
                 )
             except NoSuchElementException:
-                li = self.browser.element(
-                    self.ITEM_MATCHING_OUIA.format(text=quote(level)), parent=current_item
+                raise NavSelectionNotFound(
+                    f"{levels} not found in navigation tree. "
+                    f"Could not find element: '{self.ITEM_MATCHING.format(quote(level))}'"
                 )
             if "pf-m-expanded" not in li.get_attribute("class").split():
                 self.browser.click(li)

--- a/testing/test_nav.py
+++ b/testing/test_nav.py
@@ -2,6 +2,7 @@ import pytest
 from widgetastic.widget import View
 
 from widgetastic_patternfly4 import Navigation
+from widgetastic_patternfly4 import NavSelectionNotFound
 
 TESTING_PAGE_URL = "https://patternfly-react.surge.sh/components/navigation"
 
@@ -62,3 +63,7 @@ def test_navigation_select(browser):
     assert nav.currently_selected == ["Link 3 - expandable", "Link 2"]
     nav.select("Link 1 (not expandable)")
     assert nav.currently_selected == ["Link 1 (not expandable)"]
+
+    # try to select some bogus location and make sure proper exception is raised
+    with pytest.raises(NavSelectionNotFound):
+        nav.select("This location does not exist")


### PR DESCRIPTION
* Removing OUIA nav-item stuff as it is not in the spec
* Add a specific error message for when navigation items are not found
* Add an extra assertion to make sure the proper error is raised in the unit test

This second point is because there are several nav items in c.rh.c that exist only in CI/QA or beta/non-beta. It will be good to have a common exception when a nav selection fails so we can capture it in automation. 

cc @quarckster 