### PR TITLE
Change ouia.Button.__repr__ to use locator

### DIFF
--- a/src/widgetastic_patternfly4/button.py
+++ b/src/widgetastic_patternfly4/button.py
@@ -1,4 +1,3 @@
-from widgetastic.log import call_sig
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import ClickableMixin
 from widgetastic.widget import Widget
@@ -37,7 +36,7 @@ class BaseButton:
         return check1 or check2 or self.browser.get_attribute("disabled", self) is not None
 
     def __repr__(self):
-        return "{}{}".format(type(self).__name__, call_sig(self.args, self.kwargs))
+        return "{}{}".format(type(self).__name__, self.locator)
 
     @property
     def title(self):

--- a/testing/ouia/test_button.py
+++ b/testing/ouia/test_button.py
@@ -16,5 +16,6 @@ def view(browser):
 
 
 def test_button_click(view):
+    view.button.__repr__()
     assert view.button.is_displayed
     view.button.click()


### PR DESCRIPTION
Reference to `self.args`/`self.kwargs` caused an `AttributeError`, these are defined in `WidgetDescriptor.__new__`.

This change follows the repr pattern used by several other `Base<>` widget classes. 

FIXES #118 