### PR TITLE
Fix init method for Card class

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = testing/ouia

--- a/src/widgetastic_patternfly4/card.py
+++ b/src/widgetastic_patternfly4/card.py
@@ -10,9 +10,9 @@ class BaseCard:
 
 
 class Card(BaseCard, GenericLocatorWidget):
-    def __init__(self, parent, locator=None, logger=None, **kwargs):
-        View.__init__(self, parent, logger=logger, **kwargs)
-        self.locator = locator or ".//article[contains(@class, 'pf-c-card')]"
+    def __init__(self, parent, locator=None, logger=None):
+        locator = locator or ".//article[contains(@class, 'pf-c-card')]"
+        super().__init__(parent, locator, logger=logger)
 
     ROOT = ParametrizedLocator("{@locator}")
 

--- a/testing/ouia/test_card.py
+++ b/testing/ouia/test_card.py
@@ -9,13 +9,11 @@ TESTING_PAGE_URL = "https://patternfly-docs-ouia.netlify.app/documentation/react
 @pytest.fixture
 def view(browser):
     class TestView(View):
-        ROOT = ".//div[@id='ws-react-c-card-ouia']"
-        card = Card("Primary")
+        ROOT = ".//div[@id='ws-react-c-card-basic']"
+        card = Card("352")
 
     return TestView(browser)
 
 
 def test_card_displayed(view):
-    # TODO actually assert
-    # assert view.card.is_displayed
-    pass
+    assert view.card.is_displayed


### PR DESCRIPTION
The `Card` class inherits from `GenericLocatorWidget`, but its `__init__` method incorrectly used `View.__init__`. This caused errors when trying to initialize this widget:

```
(Pdb) view.device_summary
*** TypeError: super(type, obj): obj must be an instance or subtype of type
```

This PR fixes the `__init__` method with the correct parent class and method signature.