### PR TITLE
Simplify deploy github trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,12 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
 
 jobs:
   deploy:
     runs-on: ubuntu-20.04
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
The if clause isn't needed if `on:push:tags` is used without `on:push:branches`.  We only want to deploy on tags, so this shouldn't
change behavior, just simplify configuration