### PR TITLE
bump the selenium version from 3.14.0 to 4.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 setup_requires =
     setuptools_scm>=3.0.0
 install_requires =
-    selenium==3.141.0
+    selenium==4.1.0
     widgetastic.core>=0.62
 
 [options.packages.find]


### PR DESCRIPTION
Currently, Airgun is moving from Zalenium to Selenium Grid 4 version. To run the selenium tests we need the `selenium==4.1.0`.  when we try to update that the dependant widgetastic-patternfly4 uses an older version causing conflicts. hopefully, after the update, this will get resolved and the correct version will get installed.     

```
ERROR: Cannot install airgun and airgun==0.0.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    airgun 0.0.1 depends on selenium==4.1.0
    widgetastic-patternfly4 0.23.0 depends on selenium==3.141.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```