### PR TITLE
Add pf4 title

### DIFF
--- a/src/widgetastic_patternfly4/__init__.py
+++ b/src/widgetastic_patternfly4/__init__.py
@@ -55,6 +55,7 @@ from .table import ExpandableTable
 from .table import PatternflyTable
 from .table import RowNotExpandable
 from .tabs import Tab
+from .title import Title
 
 __all__ = [
     "Alert",
@@ -114,4 +115,5 @@ __all__ = [
     "PatternflyTable",
     "RowNotExpandable",
     "Tab",
+    "Title",
 ]

--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -1,5 +1,6 @@
 from widgetastic.ouia import OUIAGenericView
 from widgetastic.ouia import OUIAGenericWidget
+from widgetastic.ouia.text import Text as BaseOuiaText
 from widgetastic.widget.table import Table
 from widgetastic.xpath import quote
 
@@ -24,6 +25,7 @@ from widgetastic_patternfly4.select import BaseSelect
 from widgetastic_patternfly4.switch import BaseSwitch
 from widgetastic_patternfly4.table import BaseExpandableTable
 from widgetastic_patternfly4.table import BasePatternflyTable
+from widgetastic_patternfly4.title import BaseTitle
 
 
 class Alert(BaseAlert, OUIAGenericWidget):
@@ -135,3 +137,11 @@ class ContextSelector(BaseContextSelector, Select):
 
 class OptionsMenu(BaseOptionsMenu, Dropdown):
     OUIA_COMPONENT_TYPE = "PF4/OptionsMenu"
+
+
+class Title(BaseTitle, OUIAGenericWidget):
+    OUIA_COMPONENT_TYPE = "PF4/Title"
+
+
+class Text(BaseOuiaText):
+    OUIA_COMPONENT_TYPE = "PF4/Text"

--- a/src/widgetastic_patternfly4/title.py
+++ b/src/widgetastic_patternfly4/title.py
@@ -1,0 +1,33 @@
+from widgetastic.widget import ParametrizedLocator
+from widgetastic.widget import Widget
+
+
+class BaseTitle:
+    """Base class for PF4 title widget
+
+    Simple widget, but it has component classes and variable heading
+    """
+
+    @property
+    def heading_level(self):
+        return self.browser.element(self, parent=self.parent).tag_name
+
+    @property
+    def text(self):
+        return self.browser.text(self, parent=self.parent)
+
+    def read(self):
+        return self.text
+
+
+class Title(BaseTitle, Widget):
+    ROOT = ParametrizedLocator(
+        ".//*[(self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6) "
+        "and (contains(@class, 'pf-c-title') "
+        "and normalize-space(.)={@expected|quote})]"
+    )
+
+    def __init__(self, parent, text, **kwargs):
+        """Using text for parametrized locator renders read/text methods largely useless"""
+        super().__init__(parent, **kwargs)
+        self.expected = text

--- a/testing/test_title.py
+++ b/testing/test_title.py
@@ -1,0 +1,24 @@
+from widgetastic.widget import View
+
+from widgetastic_patternfly4 import Title
+
+
+TESTING_PAGE_URL = "https://patternfly-react.surge.sh/components/title"
+
+
+class TitleTestView(View):
+    h1 = Title("4xl Title")
+    h2 = Title("3xl Title")
+    h3 = Title("2xl Title")
+    h4 = Title("xl Title")
+    h5 = Title("lg Title")
+    h6 = Title("md Title")
+
+
+def test_location_and_size(browser):
+    view = TitleTestView(browser)
+    for name in view.widget_names:
+        widget = getattr(view, name)
+        assert widget.is_displayed
+        assert widget.text == widget.expected
+        assert str(widget.heading_level) == str(name)


### PR DESCRIPTION
Will take out of draft when I've got unit tests and CI is clean (#154).

Revives #150, with some additional functionality.

I believe this library should provide a near 1x1 mapping of PF4's component library in the ideal state, and this includes a class importable from the ouia module with OUIA_COMPONENT_TYPE already set when possible.  Though the base widgetastic ouia Text widget can be used and a component type passed as an argument, this is a deviation from all other PF4 component widget classes. 