### PR TITLE
Add TextInput with OUIA

### DIFF
--- a/src/widgetastic_patternfly4/ouia.py
+++ b/src/widgetastic_patternfly4/ouia.py
@@ -1,5 +1,6 @@
 from widgetastic.ouia import OUIAGenericView
 from widgetastic.ouia import OUIAGenericWidget
+from widgetastic.ouia.input import TextInput as BaseOuiaTextInput
 from widgetastic.ouia.text import Text as BaseOuiaText
 from widgetastic.widget.table import Table
 from widgetastic.xpath import quote
@@ -145,3 +146,7 @@ class Title(BaseTitle, OUIAGenericWidget):
 
 class Text(BaseOuiaText):
     OUIA_COMPONENT_TYPE = "PF4/Text"
+
+
+class TextInput(BaseOuiaTextInput):
+    OUIA_COMPONENT_TYPE = "PF4/TextInput"


### PR DESCRIPTION
Inherit base TextInput and set COMPONENT_TYPE so that the class is directly importable and usable by only passing the component_id.

Super simple, but just providing a directly importable class that follows the same pattern as all of the other PF4 OUIA supported components.
