### PR TITLE
Add element highlighting by default to the tests

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -6,6 +6,20 @@ import pytest
 from selenium import webdriver
 from wait_for import wait_for
 from widgetastic.browser import Browser
+from widgetastic.browser import BrowserParentWrapper
+
+
+class HighlightBrowser(Browser):
+    """Provide element highlighting during test execution"""
+
+    def move_to_element(self, locator, *args, **kwargs):
+        kwargs["highlight_element"] = True
+        if isinstance(self, BrowserParentWrapper):
+            parent = self._o
+            el = self._browser.element(locator, parent=parent)
+            return self._browser.move_to_element(el, *args, **kwargs)
+        else:
+            return super().move_to_element(locator, *args, **kwargs)
 
 
 OPTIONS = {"firefox": webdriver.FirefoxOptions(), "chrome": webdriver.ChromeOptions()}
@@ -73,5 +87,5 @@ def selenium(browser_name, wait_for_selenium, selenium_url):
 @pytest.fixture(scope="module")
 def browser(selenium, request):
     selenium.get(request.module.TESTING_PAGE_URL)
-    yield Browser(selenium)
+    yield HighlightBrowser(selenium)
     selenium.refresh()


### PR DESCRIPTION
Makes it easier to observe tests when making contributions

Blocked by #158 

Demonstrates the issue as well, with the check showing the following failure just from enabling highlighting:
```
=========================== short test summary info ============================
FAILED testing/test_chartpie.py::test_pie_chart[bottom-aligned] - AssertionError: assert 'rgb(0, 0, 0)' == 'rgb(0, 149, 150)'
  - rgb(0, 149, 150)
  ?        ^^^  --
  + rgb(0, 0, 0)
  ?        ^
FAILED testing/test_chartpie.py::test_pie_chart[right-aligned] - AssertionError: assert 'rgb(0, 0, 0)' == 'rgb(0, 47, 93)'
  - rgb(0, 47, 93)
  ?        ^^  ^^
  + rgb(0, 0, 0)
  ?        ^  ^
= 2 failed, 234 passed, 3 skipped, 1 xfailed, 6 warnings in 533.65s (0:08:53) ==
```