### PR TITLE
updated the path for _generate_locator in button.py

### DIFF
--- a/src/widgetastic_patternfly4/button.py
+++ b/src/widgetastic_patternfly4/button.py
@@ -92,7 +92,8 @@ class Button(BaseButton, Widget, ClickableMixin):
         return (
             ".//*[(self::a or self::button or (self::input and "
             "(@type='button' or @type='submit'))) and "
-            f"contains(@class, 'pf-c-button') {locator_conditions}]"
+            f"contains(@class, 'pf-c-button') or "
+            f"contains(@class, 'btn btn-default') {locator_conditions}]"
         )
 
     def __init__(self, parent, *text, **kwargs):


### PR DESCRIPTION
The button locator for the alert option differs from other buttons. To accurately identify the locator, I added the condition "`or contains(@class, 'btn btn-default')`" to the Path.