### PR TITLE
Use timeout instead of num_sec

### DIFF
--- a/src/widgetastic_patternfly4/chipgroup.py
+++ b/src/widgetastic_patternfly4/chipgroup.py
@@ -102,7 +102,7 @@ class Chip(ParametrizedView, _BaseChip):
 
         if not self.read_only:
             self.button.click()
-            wait_for(_gone, num_sec=3, message="wait for chip to dissappear", delay=0.1)
+            wait_for(_gone, timeout=3, message="wait for chip to disappear", delay=0.1)
         else:
             raise ChipReadOnlyError(self, "Chip is read-only")
 
@@ -131,7 +131,7 @@ class OverflowChip(_BaseChip):
             self._text.click()
         wait_for(
             func=self._show_less_shown,
-            num_sec=3,
+            timeout=3,
             delay=0.1,
             message="wait for 'show less' button to appear",
         )
@@ -142,7 +142,7 @@ class OverflowChip(_BaseChip):
             self._text.click()
         wait_for(
             self._show_more_shown,
-            num_sec=3,
+            timeout=3,
             delay=0.1,
             message="wait for 'show more' button to appear",
         )

--- a/src/widgetastic_patternfly4/navigation.py
+++ b/src/widgetastic_patternfly4/navigation.py
@@ -41,7 +41,7 @@ class BaseNavigation:
             self.logger.info("Navigation not ready yet")
             wait_for(
                 lambda: self.browser.element(".").get_attribute("data-ouia-safe") == "true",
-                num_sec=10,
+                timeout=10,
             )
         elif not out:
             self.logger.info("Navigation doesn't have 'data-ouia-safe' property")

--- a/testing/ouia/test_pagination_ouia.py
+++ b/testing/ouia/test_pagination_ouia.py
@@ -19,7 +19,7 @@ def paginator(browser, request):
         paginator = Pagination("pagination-options-menu-top")
 
     paginator = TestView(browser).paginator
-    wait_for(lambda: paginator.is_displayed, num_sec=10)
+    wait_for(lambda: paginator.is_displayed, timeout=10)
     yield paginator
     try:
         paginator.first_page()

--- a/testing/test_cardview.py
+++ b/testing/test_cardview.py
@@ -33,7 +33,7 @@ class Cards(CardGroup):
 @pytest.fixture
 def cards(browser):
     cards = Cards(browser)
-    wait_for(lambda: cards.is_displayed, timeout="15s")
+    wait_for(lambda: cards.is_displayed, timeout=15)
     return cards
 
 

--- a/testing/test_pagination.py
+++ b/testing/test_pagination.py
@@ -20,7 +20,7 @@ def _paginator(browser, request, reset_elements_per_page=True):
         paginator = paginator_cls(locator="./div")
 
     paginator = TestView(browser).paginator
-    wait_for(lambda: paginator.is_displayed, num_sec=10)
+    wait_for(lambda: paginator.is_displayed, timeout=10)
     yield paginator
     try:
         paginator.first_page()


### PR DESCRIPTION
Future release of wait_for will deprecate `num_sec` parameter and timeout usage with time as a string value.
This PR makes changes based on this.



Related PRs:
https://github.com/RedHatQE/widgetastic.core/pull/309
https://github.com/RedHatQE/widgetastic.patternfly5/pull/125

## Summary by Sourcery

Update wait_for usage to rely on the timeout parameter instead of the deprecated num_sec and string-based time values.

Enhancements:
- Use the timeout argument consistently in widget navigation and chip group helpers to align with upcoming wait_for API changes.
- Correct a typo in the chip removal wait message text.

Tests:
- Update pagination and card view tests to use the timeout argument with numeric values instead of num_sec or string-based durations.